### PR TITLE
Add custom exception handlers for ViewModels

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ ViewModel(factory = { TestViewModel() }) { viewModel ->
 
 #### Custom ViewModel's exception handlers 
 
+> **Note:** When using a custom exception handler you need to take care about crash reporting
+
 Shared exception handlers (for all ViewModels)
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -73,6 +73,35 @@ ViewModel(factory = { TestViewModel() }) { viewModel ->
 }
 ```
 
+#### Custom ViewModel's exception handlers 
+
+Shared exception handlers (for all ViewModels)
+
+```kotlin
+class App: Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        KViewModel.setupSharedExceptionHandler(CoroutineExceptionHandler { _, throwable ->
+            // There is you can log common exceptions for all ViewModels
+        })
+    }
+}
+```
+
+Single exception handlers (for only current ViewModel)
+
+```kotlin
+class TestViewModel: BaseSharedViewModel<TestViewState, TestAction, TestEvent>(initialState = TestViewState()) {
+    
+    override fun getCoroutineExceptionHandler(): CoroutineExceptionHandler {
+        return CoroutineExceptionHandler { _, throwable ->
+            // There is you can log exceptions only for TestViewModel
+        }
+    }
+}
+```
+
 #### [Odyssey](https://github.com/AlexGladkov/Odyssey) integration
 Allows you to save the ViewModel
 ```kotlin

--- a/kviewmodel/src/commonMain/kotlin/com/adeo/kviewmodel/KViewModel.kt
+++ b/kviewmodel/src/commonMain/kotlin/com/adeo/kviewmodel/KViewModel.kt
@@ -10,8 +10,8 @@ import kotlin.native.concurrent.ThreadLocal
 
 public abstract class KViewModel {
 
-    private val mainCoroutineExceptionHandler: CoroutineExceptionHandler? by lazy {
-        getCoroutineExceptionHandler() ?: sharedExceptionHandler
+    private val mainCoroutineExceptionHandler: CoroutineExceptionHandler? by lazy(LazyThreadSafetyMode.NONE) {
+        getCoroutineExceptionHandler()
     }
     private val coroutineTags = hashMapOf<String, CoroutineScope>()
     private val mainCoroutineContext = (SupervisorJob() + Dispatchers.Main.immediate).run {

--- a/kviewmodel/src/commonMain/kotlin/com/adeo/kviewmodel/KViewModel.kt
+++ b/kviewmodel/src/commonMain/kotlin/com/adeo/kviewmodel/KViewModel.kt
@@ -1,16 +1,28 @@
 package com.adeo.kviewmodel
 
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlin.coroutines.CoroutineContext
+import kotlin.native.concurrent.ThreadLocal
 
 public abstract class KViewModel {
 
+    private val mainCoroutineExceptionHandler: CoroutineExceptionHandler? by lazy {
+        getCoroutineExceptionHandler() ?: sharedExceptionHandler
+    }
     private val coroutineTags = hashMapOf<String, CoroutineScope>()
+    private val mainCoroutineContext = (SupervisorJob() + Dispatchers.Main.immediate).run {
+        val exceptionHandler = mainCoroutineExceptionHandler ?: return@run this
+        this + exceptionHandler
+    }
 
     public val viewModelScope: CoroutineScope
         get() = coroutineTags[MAIN_JOB_KEY] ?: launchNewScope()
+
+    protected open fun getCoroutineExceptionHandler(): CoroutineExceptionHandler? = sharedExceptionHandler
 
     protected open fun onCleared() {
 
@@ -22,13 +34,22 @@ public abstract class KViewModel {
     }
 
     // Launch view model scope except you provide a new key
-    public fun launchNewScope(key: String = MAIN_JOB_KEY): CoroutineScope =
+    public fun launchNewScope(
+        key: String = MAIN_JOB_KEY,
+        coroutineContext: CoroutineContext = mainCoroutineContext
+    ): CoroutineScope =
         coroutineTags.getOrPut(key) {
-            CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+            CoroutineScope(coroutineContext)
         }
 
+    @ThreadLocal
     public companion object {
+        private var sharedExceptionHandler: CoroutineExceptionHandler? = null
         private const val MAIN_JOB_KEY = "main.viewmodel.shared.coroutine.job"
+
+        public fun setupSharedExceptionHandler(exceptionHandler: CoroutineExceptionHandler) {
+            sharedExceptionHandler = exceptionHandler
+        }
     }
 
 }


### PR DESCRIPTION
Fix this issue: https://github.com/adeo-opensource/kviewmodel--mpp/issues/13

Add opportunities for: 
1) Add common (shared) CoroutineExceptionHandlers for all ViewModels. It is convenient, because often application need only one single common ExceptionHandler for logging exceptions to Firebase Crashlytics
2) Add custom CoroutineExceptionHandler for current ViewModel. It adds more flexibility and may be useful in some cases. For example, on some screens we want to show snackbars with exception descriptions